### PR TITLE
Don't delete local variable

### DIFF
--- a/lib/ansible-vault.js
+++ b/lib/ansible-vault.js
@@ -103,9 +103,6 @@ export default {
       complete.process.on('close', function () {
          this.parentView.notifyMessage(this.exitCode,output,error)
       });
-      delete output;
-      delete error;
-      delete password;
   },
 
   toggle() {


### PR DESCRIPTION
In the process of upgrading babel in Atom core (https://github.com/atom/atom/pull/13823) we have noticed this package uses JavaScript features that are either deprecated or that are incompatible with the language specification.

This pull request changes the code to stop using such features so that the package keeps working when the babel upgrade will be merged and released.

I have enabled edits from maintainers, so feel free to make any changes to this branch! Also, please let me know if you have any questions or concerns and if I can help somehow. Thanks!