### PR TITLE
Selection based encrypt/decrypt

### DIFF
--- a/lib/ansible-vault-utils.js
+++ b/lib/ansible-vault-utils.js
@@ -37,7 +37,7 @@ export default class AnsibleVaultUtils {
       if (event.keyCode == 13) {
         if (prevKey !== 13) {
           if (master instanceof AnsibleVaultUtils) {
-            master.ExecAction(vault_filepath, action, inputbox.value);
+            master.ExecAction(editor, vault_filepath, action, inputbox.value);
             if (action == "decrypt") {
               editor.password = inputbox.value;
               inputbox.value = "";
@@ -92,7 +92,7 @@ export default class AnsibleVaultUtils {
     return ansible_cfg_file;
   }
 
-  VaultFile(vault_filepath, action, password_file, unlinkF) {
+  VaultFile(editor, vault_filepath, action, password_file) {
     let father = this;
     cmd = [atom.config.get("ansible-vault.path"), action];
 
@@ -125,26 +125,31 @@ export default class AnsibleVaultUtils {
           output = stderr;
         } else {
           exitCode = 0;
-          output = vault_filepath + ": OK";
-          if (action == "encrypt") {
-            atom.workspace.getActiveTextEditor().getBuffer().onDidStopChanging( () => {
-              atom.workspace.getActiveTextEditor().getBuffer().clearUndoStack()
-            })
-          }
+          output = action.toUpperCase() + ": OK";
+
+          // Update selection
+          fs.readFile(vault_filepath, 'utf8', function(err, contents) {
+              editor.insertText(contents);
+          });
         }
+
+        // Delete temp vault file
+        fs.unlink(vault_filepath, () => {});
+
+        // Delete the temp password file if used
+        if (password_file.endsWith(".vault.temp")) {
+          fs.unlink(password_file, () => {});
+        }
+
+        // Notify status
         father.notifyMessage(exitCode, output, stderr);
-        if (unlinkF) fs.unlink(password_file, () => {});
       }
     );
   }
 
-  ExecAction(vault_filepath, action, password) {
-    let output = [];
-    let error = [];
-    let password_file = "";
+  getPasswordFile(vault_filepath, pass) {
     let father = this;
-    let complete = null;
-    let unlinkF = false;
+    let password_file = "";
 
     if (atom.config.get("ansible-vault.vault_password_file_forcing")) {
       password_file = atom.config.get("ansible-vault.vault_password_file_path");
@@ -170,24 +175,60 @@ export default class AnsibleVaultUtils {
       }
     }
 
-    if (password_file == "") {
-      filename =
-        __dirname +
-        "/" +
-        Math.random()
-          .toString(36)
-          .substring(2) +
-        ".vault";
-      filePT = new File(filename, false);
-      filePT.create().then(function() {
-        filePT.writeSync(password);
-        password_file = filename;
-        unlinkF = true;
-        father.VaultFile(vault_filepath, action, password_file, unlinkF);
+    // Write to temp password file
+    if (password_file == "" && pass) {
+      filename = father.GenFileName() + ".vault.temp";
+      pfile = new File(filename, false);
+      pfile.create().then(function() {
+        pfile.writeSync(pass);
       });
-    } else {
-      father.VaultFile(vault_filepath, action, password_file, unlinkF);
+      password_file = filename;
     }
+
+    return password_file;
+  }
+
+  GenFileName() {
+    return __dirname +
+    "/." +
+    Math.random()
+      .toString(36)
+      .substring(2);
+  }
+
+  getSelection(editor) {
+    vault_text = editor.getSelectedText();
+
+    // If nothing selected, assume we are encrypting the whole file
+    if (vault_text.length == 0) {
+      editor.selectAll();
+      vault_text = editor.getSelectedText();
+    }
+
+    return vault_text;
+  }
+
+  ExecAction(editor, vault_filepath, action, password) {
+    let output = [];
+    let error = [];
+    let password_file = "";
+    let vault_text = "";
+    let temp_vault = "";
+    let father = this;
+    let complete = null;
+
+    password_file = father.getPasswordFile(vault_filepath, password);
+    vault_text = father.getSelection(editor);
+
+    // Write selection to a temp file
+    temp_vault = father.GenFileName() + ".temp";
+    filePT = new File(temp_vault, false);
+    filePT.create().then(function() {
+      filePT.writeSync(vault_text);
+    });
+
+    // Process selection as a vault file
+    father.VaultFile(editor, temp_vault, action, password_file);
   }
 
   DisableAuto() {
@@ -225,12 +266,13 @@ export default class AnsibleVaultUtils {
                     if (
                       atom.config.get("ansible-vault.vault_password_file_flag")
                     ) {
-                      father.ExecAction(vault_filepath, "encrypt", "");
+                      father.ExecAction(editor, vault_filepath, "encrypt", "");
                     } else {
                       father.ExecAction(
+                        editor,
                         vault_filepath,
                         "encrypt",
-                        event.item.password
+                        event.item.password,
                       );
                     }
                   }
@@ -242,7 +284,7 @@ export default class AnsibleVaultUtils {
               atom.config.get("ansible-vault.vault_password_file_flag") ||
               atom.config.get("ansible-vault.vault_password_file_forcing")
             ) {
-              father.ExecAction(editor.getPath(), "decrypt", "");
+              father.ExecAction(editor, editor.getPath(), "decrypt", "");
             } else {
               father.inputboxHandler(
                 inputbox,

--- a/lib/ansible-vault.js
+++ b/lib/ansible-vault.js
@@ -35,7 +35,7 @@ export default {
 
     this.subscriptions = new CompositeDisposable();
     this.subscriptions.add(atom.commands.add('atom-workspace', {
-      'ansible-vault:toggle': () => this.toggle()
+      'ansible-vault:toggle': () => this.toggleSelection()
     }));
 
     // async check ansible-vault binary
@@ -72,7 +72,7 @@ export default {
   checkActiveEditor() {
     let editor = atom.workspace.getActiveTextEditor();
     if (typeof editor !== 'undefined' && editor.getPath) {
-      return editor
+      return editor;
     } else {
       throw "File not selected!";
     }
@@ -89,15 +89,23 @@ export default {
       let editor = this.checkActiveEditor();
       let vault_filepath = this.getFilename(editor);
 
-      if (editor.getText().substring(0,14) == "$ANSIBLE_VAULT") {
+      vault_text = editor.getSelectedText();
+
+      // If nothing selected, assume we are encrypting the whole file
+      if (vault_text.length == 0) {
+        editor.selectAll();
+        vault_text = editor.getSelectedText();
+      }
+
+      if (vault_text.substring(0,14) == "$ANSIBLE_VAULT") {
         action = "decrypt";
       } else {
         action = "encrypt";
       }
-      obj_utils.ExecAction(vault_filepath, action, password);
+      obj_utils.ExecAction(editor, vault_filepath, action, password);
   },
 
-  toggle() {
+  toggleSelection() {
 
     if(atom.packages.isPackageActive('ansible-vault') == false ) {
       obj_utils.notifyMessage(3,"","ERROR: Ansible-vault package is deactivated!\n\n Probably need to configure the absolute path in settings. After change the path you need to disable and enable package again!\n Check the reference: https://github.com/sydro/atom-ansible-vault.\n");
@@ -111,21 +119,23 @@ export default {
         editor = this.checkActiveEditor();
     } catch (e) {
         obj_utils.notifyMessage(2,"","ERROR: " + e);
-        return
+        return;
     }
+
     let vault_filepath = this.getFilename(editor);
-    if (editor.getText().substring(0,14) == "$ANSIBLE_VAULT") {
+    let selection = obj_utils.getSelection(editor);
+
+    if (selection.substring(0,14) == "$ANSIBLE_VAULT") {
       action = "decrypt";
     } else {
       action = "encrypt";
     }
 
     if (atom.config.get('ansible-vault.vault_password_file_flag') || atom.config.get('ansible-vault.vault_password_file_forcing') ) {
-      obj_utils.ExecAction(vault_filepath, action, "");
+      obj_utils.ExecAction(editor, vault_filepath, action, "");
     } else {
-
       if (this.modalPanel.isVisible()) {
-        this.modalPanel.hide()
+        this.modalPanel.hide();
       } else {
         let inputbox = this.ansibleVaultView.getElement().children[1];
         inputbox.parentView = this;

--- a/menus/ansible-vault.json
+++ b/menus/ansible-vault.json
@@ -2,7 +2,7 @@
   "context-menu": {
     "atom-text-editor": [
       {
-        "label": "Toggle AnsibleVault",
+        "label": "AnsibleVault - Encrypt/Decrypt",
         "command": "ansible-vault:toggle"
       }
     ]

--- a/spec/ansible-vault-spec.js
+++ b/spec/ansible-vault-spec.js
@@ -43,7 +43,7 @@ describe('Atom Ansible Vault', () => {
     expect(AnsibleVault.config.vault_password_file_forcing.default).toBe(false)
     expect(AnsibleVault.config.vault_password_file_path.default).toBe('/tmp/pass.txt')
     expect(AnsibleVault.config.vault_automatic_de_and_encrypt.default).toBe(false)
-    expect(AnsibleVault.toggle).toBeDefined()
+    expect(AnsibleVault.toggleSelection).toBeDefined()
   })
 
   it('should visible the inputbox when toggled', () => {


### PR DESCRIPTION
This revision changes the approach of how the plugin encrypts/decrypts. The previous approach encrypts/decrypts the file directly. This has several disadvantages (to an otherwise great plugin!), including no support of inline encryption/decryption, requires the file to be saved prior to encrypt/decrypt, and doesn't allow 'undo'.

The following PR enables highlighted text encryption, or if nothing is highlighted the entire file will be selected and then encrypted/decrypted. This allows the user to see results prior to saving.

Thanks!